### PR TITLE
Fix GrammarName issue for Node and allow to open in Full window

### DIFF
--- a/lib/Repl-View/ReplView.coffee
+++ b/lib/Repl-View/ReplView.coffee
@@ -113,7 +113,8 @@ class REPLView
     @ignore = false
     #@minimaltext = ""
     uri = "REPL: "+@grammarName
-    atom.workspace.open(uri,split:'right').done (textEditor) =>
+    opts = split:'right' if atom.config.get('Repl.splitRight')
+    atom.workspace.open(uri, opts).done (textEditor) =>
           pane = atom.workspace.getActivePane()
           if(self.grammarName == "Python Console3" || self.grammarName == "Python Console2" || self.grammarName == "Python")
             @grammarName = "Python Console"

--- a/lib/Repl-View/ReplView.coffee
+++ b/lib/Repl-View/ReplView.coffee
@@ -51,9 +51,10 @@ class REPLView
 
   setGrammar : =>
     grammars = atom.grammars.getGrammars()
+    gName = if @grammarName == 'Node' then 'JavaScript' else @grammarName
     #console.log(grammars[0])
     for grammar in grammars
-      if (grammar.name ==  @grammarName)
+      if (grammar.name ==  gName)
         #console.log(grammar)
         @replTextEditor.setGrammar(grammar)
         return

--- a/lib/Repl.coffee
+++ b/lib/Repl.coffee
@@ -46,6 +46,11 @@ config:
       title: 'R'
       default: 'R'
       description: 'path to R'
+    splitRight:
+      type: 'boolean'
+      title: 'Open Repl in the rightmost pane'
+      default: true
+      description: 'Whether to open Repl editor in rightmost pane'
 
   #myREPLView: null
   #modalPanel: null


### PR DESCRIPTION
REPL now doesn't set grammar for Node REPL, because there's no Grammar object with name 'Node', instead it is 'JavaScript'.

Also, Add config to allow open the Repl pane in full window