### PR TITLE
use empty prompt string

### DIFF
--- a/Repls/replOcaml.js
+++ b/Repls/replOcaml.js
@@ -1,6 +1,6 @@
 module.exports =
 cmd=atom.config.get('Repl.ocaml')
-prompt='>>>'
+prompt=''
 //until they fix OCAML syntax
 args=['-noprompt']
 endSequence=';;\n'


### PR DESCRIPTION
non-empty prompt string trigger errors for second snippet. It always report a syntax error in characters 0-2.
I don't know the exact reformatting that Repl is doing but using a empty prompt at least works.